### PR TITLE
Update build.gradle to add namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
+    namespace "com.flutter_media_downloader.flutter_media_downloader"
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
in newer versions of the Android Gradle Plugin (AGP). Starting with AGP 7.0, projects are required to specify a namespace in the module's build file.