### PR TITLE
Task: Update Permission Logic.

### DIFF
--- a/lib/flutter_media_downloader.dart
+++ b/lib/flutter_media_downloader.dart
@@ -48,8 +48,7 @@ class MediaDownload {
                 FileNameFormat().fileNameWithOutExtension(url);
 
             debugPrint('Android fileExtension $fileExtension');
-            debugPrint(
-                'Android nameWithoutExtension $nameWithoutExtension');
+            debugPrint('Android nameWithoutExtension $nameWithoutExtension');
             debugPrint(
                 'Android  ${baseStorage?.path}/$nameWithoutExtension.$fileExtension');
             final File file = File(
@@ -175,11 +174,66 @@ class MediaDownload {
   }
 
   Future<void> requestPermission() async {
-    final PermissionStatus status = await Permission.storage.request();
-    final PermissionStatus notificationStatus =
-        await Permission.notification.request();
-    if (status.isGranted && notificationStatus.isGranted) {
-    } else {}
+    final bool storageMediaStatus =
+        (await requestMediaPermissions() || await requestStoragePermission());
+    final bool notificationStatus = await processNotificationPermission();
+    debugPrint(
+        'requestPermission: storageMediaStatus: $storageMediaStatus, notificationStatus: $notificationStatus');
+  }
+
+  /// permission-storage/media
+  // 1. Process storage permission
+  Future<bool> requestStoragePermission() async {
+    try {
+      if (await Permission.storage.isGranted) {
+        return true;
+      } else {
+        var status = await Permission.storage.request();
+        if (status.isGranted) {
+          return true;
+        }
+      }
+      return false;
+    } on Exception catch (e) {
+      debugPrint('requestStoragePermission: E: $e *');
+      return false;
+    }
+  }
+
+  // 2. Process media permissions
+  Future<bool> requestMediaPermissions() async {
+    try {
+      Map<Permission, PermissionStatus> statuses = await [
+        Permission.photos,
+        Permission.videos,
+        Permission.audio,
+      ].request();
+
+      return statuses[Permission.photos]?.isGranted == true &&
+          statuses[Permission.videos]?.isGranted == true &&
+          statuses[Permission.audio]?.isGranted == true;
+    } on Exception catch (e) {
+      debugPrint('requestMediaPermissions: E: $e *');
+      return false;
+    }
+  }
+
+  /// permission-notification
+  Future<bool> processNotificationPermission() async {
+    try {
+      if (await Permission.notification.isGranted) {
+        return true;
+      } else {
+        var status = await Permission.notification.request();
+        if (status.isGranted) {
+          return true;
+        }
+      }
+      return false;
+    } on Exception catch (e) {
+      debugPrint('processNotificationPermission: E: $e *');
+      return false;
+    }
   }
 
   ///showCustomNotification(iOS Code)


### PR DESCRIPTION
This is due to the following issue(s) with permission-storage:
`Permission for accessing external storage.

Depending on the platform and version, the requirements are slightly different:

Android:

On Android 13 (API 33) and above, this permission is deprecated and always returns PermissionStatus.denied. Instead use Permission.photos, Permission.video, Permission.audio or Permission.manageExternalStorage. For more information see our [FAQ](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html).
Below Android 13 (API 33), the READ_EXTERNAL_STORAGE and WRITE_EXTERNAL_STORAGE permissions are requested (depending on the definitions in the AndroidManifest.xml) file.`